### PR TITLE
Fix handling of *const *const ptr

### DIFF
--- a/src/bindgen/items.rs
+++ b/src/bindgen/items.rs
@@ -256,13 +256,17 @@ impl Type {
         }
     }
 
-    fn to_string(&self) -> String {
+    fn to_string(&self, already_const: bool) -> String {
         match self {
             &Type::ConstPtr(ref t) => {
-                format!("const {}*", t.to_string())
+                if already_const {
+                    format!("{}*", t.to_string(true))
+                } else {
+                    format!("const {}*", t.to_string(true))
+                }
             }
             &Type::Ptr(ref t) => {
-                format!("{}*", t.to_string())
+                format!("{}*", t.to_string(already_const))
             }
             &Type::Path(ref p) => {
                 p.clone()
@@ -271,13 +275,13 @@ impl Type {
                 format!("{}", p)
             }
             &Type::Array(ref t, ref sz) => {
-                format!("{}[{}]", t.to_string(), sz)
+                format!("{}[{}]", t.to_string(already_const), sz)
             }
             &Type::FuncPtr(ref ret, ref args) => {
                 let mut out = String::new();
 
                 if let &Some(ref ret) = ret {
-                    out.push_str(&ret.to_string());
+                    out.push_str(&ret.to_string(already_const));
                 } else {
                     out.push_str("void");
                 }
@@ -286,7 +290,7 @@ impl Type {
                     if i != 0 {
                         out.push_str(", ");
                     }
-                    out.push_str(&arg.to_string());
+                    out.push_str(&arg.to_string(already_const));
                 }
                 out.push_str(")");
 
@@ -295,13 +299,17 @@ impl Type {
         }
     }
 
-    fn to_string_with_ident(&self, ident: &str) -> String {
+    fn to_string_with_ident(&self, ident: &str, already_const: bool) -> String {
         match self {
-            &Type::ConstPtr(ref t) => {
-                format!("const {}* {}", t.to_string(), ident)
+            &Type::ConstPtr(ref t)  => {
+                if already_const {
+                    format!("{}* {}", t.to_string(true), ident)
+                } else {
+                    format!("const {}* {}", t.to_string(true), ident)
+                }
             }
             &Type::Ptr(ref t) => {
-                format!("{}* {}", t.to_string(), ident)
+                format!("{}* {}", t.to_string(already_const), ident)
             }
             &Type::Path(ref p) => {
                 format!("{} {}", p, ident)
@@ -310,13 +318,13 @@ impl Type {
                 format!("{} {}", p, ident)
             }
             &Type::Array(ref t, ref sz) => {
-                format!("{} {}[{}]", t.to_string(), ident, sz)
+                format!("{} {}[{}]", t.to_string(already_const), ident, sz)
             }
             &Type::FuncPtr(ref ret, ref args) => {
                 let mut out = String::new();
 
                 if let &Some(ref ret) = ret {
-                    out.push_str(&ret.to_string());
+                    out.push_str(&ret.to_string(already_const));
                 } else {
                     out.push_str("void");
                 }
@@ -327,7 +335,7 @@ impl Type {
                     if i != 0 {
                         out.push_str(", ");
                     }
-                    out.push_str(&arg.to_string());
+                    out.push_str(&arg.to_string(already_const));
                 }
                 out.push_str(")");
 
@@ -337,7 +345,7 @@ impl Type {
     }
 
     fn write_with_ident<F: Write>(&self, ident: &str, out: &mut Writer<F>) {
-        out.write(&self.to_string_with_ident(ident));
+        out.write(&self.to_string_with_ident(ident, false));
     }
 }
 
@@ -411,11 +419,11 @@ impl Function {
 
         let prefix = config.function.prefix(&self.directives);
         let ret = match self.ret.as_ref() {
-            Some(ret) => ret.to_string(),
+            Some(ret) => ret.to_string(false),
             None => format!("void"),
         };
         let name = &self.name;
-        let args = self.args.iter().map(|x| x.1.to_string_with_ident(&x.0)).collect::<Vec<_>>();
+        let args = self.args.iter().map(|x| x.1.to_string_with_ident(&x.0, false)).collect::<Vec<_>>();
         let postfix = config.function.postfix(&self.directives);
 
         let option_1: usize = prefix.as_ref().map_or(0, |x| x.len()) +
@@ -465,7 +473,7 @@ impl Function {
             out.write(";");
         } else {
             // 3. PREFIX
-            //    RET NAME ( ARGS 
+            //    RET NAME ( ARGS
             //               ... )
             //    POSTFIX ;
 


### PR DESCRIPTION
Translating `*const *const my_type` ptr to c/c++ resulted in invalid code(`const const my_type**`)