### PR TITLE
Added QualifiedScreamingSnakeCase

### DIFF
--- a/src/bindgen/items.rs
+++ b/src/bindgen/items.rs
@@ -631,7 +631,7 @@ impl Enum {
         if let Some(r) = find_first_some(&rules) {
             self.values = self.values.iter()
                                      .map(|x| (r.apply_to_pascal_case(&x.0,
-                                                                      IdentifierType::EnumVariant),
+                                                                      IdentifierType::EnumVariant(self)),
                                                x.1.clone()))
                                      .collect();
         }

--- a/src/bindgen/rust_lib.rs
+++ b/src/bindgen/rust_lib.rs
@@ -7,12 +7,12 @@ use bindgen::cargo_expand;
 use bindgen::cargo_metadata;
 use syn;
 
-const STD_CRATES: &[&'static str] = &["std",
-                                      "std_unicode",
-                                      "alloc",
-                                      "collections",
-                                      "core",
-                                      "proc_macro"];
+const STD_CRATES: &'static [&'static str] = &["std",
+                                              "std_unicode",
+                                              "alloc",
+                                              "collections",
+                                              "core",
+                                              "proc_macro"];
 
 type ParseResult = Result<(), String>;
 


### PR DESCRIPTION
This adds support for a new rename rule `QualifiedScreamingSnakeCase` for #20.

The difference to `ScreamingSnakeCase` is that enum variants are prefixed with the enum type.