### PR TITLE
Fixed example building.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ use std::env;
 fn main() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
-    cbindgen::generate(crate_dir)
+    cbindgen::generate(&crate_dir)
       .unwrap()
       .write_to_file("bindings.h");
 }


### PR DESCRIPTION
Fix:

```rust
 --> build.rs:8:24
  |
8 |     cbindgen::generate(crate_dir)
  |                        ^^^^^^^^^ expected &str, found struct `std::string::String`
  |
  = note: expected type `&str`
             found type `std::string::String`
  = help: try with `&crate_dir`
```